### PR TITLE
Refactor `Projects` page layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Elements are described in the position paper
 - [Miniscope imaging](https://github.com/datajoint/element-miniscope)
   - [Example workflow](https://github.com/datajoint/workflow-miniscope)
 
-### DataJoint Elements coming soon
+### DataJoint Elements in development
 - [DeepLabCut](https://github.com/datajoint/element-deeplabcut)
-- [Trial-based experiments](https://github.com/datajoint/element-trial)
+- [Event- and trial-based experiments](https://github.com/datajoint/element-event)
 - [Electrode localization for Neuropixels](https://github.com/datajoint/element-electrode-localization)
 - [Facemap](https://github.com/datajoint/element-facemap)
 

--- a/gh-pages/docs/community/projects.md
+++ b/gh-pages/docs/community/projects.md
@@ -28,7 +28,11 @@ Please visit our <a href="https://catalog.datajoint.io/" target="_blank">Catalog
             <li><a href="https://wittenlab.org" target="_blank">Ilana Witten Lab</a></li>
             <li><a href="https://pillowlab.princeton.edu" target="_blank">Jonathan Pillow Lab</a></li>
         </ul>
-        <li>Rochester<a href="https://reporter.nih.gov/project-details/10047607" target="_blank"> Neural basis of causal inference</a></li>
+        <li>Rochester-Harvard-NYU<a href="https://reporter.nih.gov/project-details/10047607" target="_blank"> Neural basis of causal inference</a></li>
+            <ul>
+            <li><a href="http://www.sas.rochester.edu/bcs/people/faculty/deangelis_greg/index.html" target="_blank">Greg DeAngelis, University of Rochester</a></li>
+            <li><a href="https://angelakilabnyu.org/" target="_blank">Dora Angelaki Lab, New York University</a></li>
+            </ul>
         </ul>
     </li>
 </ul>
@@ -37,35 +41,27 @@ Please visit our <a href="https://catalog.datajoint.io/" target="_blank">Catalog
 <h3>Individual Labs</h3>
 
 <ul>
-    <li>Allen Institute <a href="https://alleninstitute.org/what-we-do/brain-science/research/mindscope-program/" target="_blank">Mindscope Program</a>
+    <li>Allen Institute
+        <ul>
+        <li><a href="https://alleninstitute.org/what-we-do/brain-science/research/mindscope-program/" target="_blank">Mindscope Program</a></li>
+        </ul>
+    </li>
+    <li>Arizona State University
+        <ul>
+        <li><a href="https://isearch.asu.edu/profile/500553" target="_blank">Rick Gerkin</a></li>
+        </ul>
+    </li>
     <li>Baylor College of Medicine
         <ul>
-        <li><a href="https://toliaslab.org/" target="_blank">Tolias Lab</a></li>
+        <li><a href="https://toliaslab.org/" target="_blank">Andreas Tolias Lab</a></li>
         <li><a href="https://www.bcm.edu/research/faculty-labs/jacob-reimer-lab" target="_blank">Reimer Lab</a></li>
         <li><a href="https://www.bcm.edu/research/faculty-labs/paul-pfaffinger-lab" target="_blank">Pfaffinger Lab</a></li>
-        <li><a href="https://www.bcm.edu/research/faculty-labs/matthew-mcginley-lab" target="_blank">McGinley Lab</a></li>
+        <li><a href="https://www.bcm.edu/research/faculty-labs/matthew-mcginley-lab" target="_blank">Matthew McGinley Lab</a></li>
         </ul>
     </li>
-    <li>Wilhelm Schickard Institute for Computer Science
+    <li>Bonn University
         <ul>
-        <li><a href="https://sinzlab.org/" target="_blank">Sinz Lab</a></li>
-        <li><a href="https://philippberens.wordpress.com/" target="_blank">Berens Lab</a></li>
-        <li><a href="http://www.eye-tuebingen.de/eulerlab/" target="_blank">Euler Lab</a></li>
-        <li><a href="http://bethgelab.org/" target="_blank">Bethge Lab</a></li>
-        </ul>
-    </li>
-    <li>Ludwig-Maximilians-Universität München
-        <ul>
-        <li><a href="https://www.neuro.bio.lmu.de/research_groups/res-busse_l/index.html" target="_blank">Busse Lab</a></li>
-        <li><a href="https://www.neuro.bio.lmu.de/research_groups/res-katzner/index.html" target="_blank">Katzner Lab</a></li>
-        </ul>
-    </li>
-    <li>Harvard Medical School
-        <ul>        
-        <li><a href="https://harveylab.hms.harvard.edu/" target="_blank">Harvey Lab</a></li>
-        <li><a href="http://datta.hms.harvard.edu/" target="_blank">Datta Lab</a></li>
-        <li><a href="http://sabatini.hms.harvard.edu/" target="_blank">Sabatini Lab</a></li>
-        <li><a href="https://smirnakislab.bwh.harvard.edu/" target="_blank">Smirnakis Lab</a></li>
+        <li><a href="https://rose-group.ieecr-bonn.de" target="_blank">Tobias Rose Lab</a></li>
         </ul>
     </li>
     <li>Boston University
@@ -74,21 +70,63 @@ Please visit our <a href="https://catalog.datajoint.io/" target="_blank">Catalog
         <li><a href="https://www.scottcognitionlab.com" target="_blank">Benjamin Scott Lab</a></li>
         </ul>
     </li>
-    <li>Bonn University <a href="https://www.uni-bonn.de/en/news/280-2021" target="_blank">SFB 1089</a></li>
-    <li><a href="https://www.ntnu.edu/kavli/moser-group" target="_blank">Moser Group, Kavli Institute for Systems Neuroscience</a></li>
-    <li><a href="http://www.mackenziemathislab.org/" target="_blank">Mackenzie Mathis Lab, EPFL</a></li>
-    <li><a href="https://churchlandlab.org/" target="_blank">Anne Churchland Lab, UCLA</a></li>
-    <li><a href="http://www.lulaboratory.com/" target="_blank">Lu Lab, University of Indiana</a></li>
-    <li><a href="http://web.stanford.edu/group/dlab/" target="_blank">Karl Deisseroth Lab, Stanford University</a></li>
-    <li><a href="https://www.wanglab-neuro.org" target="_blank">Fan Wang, MIT</a></li>
-    <li><a href="https://angelakilabnyu.org/" target="_blank">Angelaki Lab, New York University</a></li>
-    <li><a href="http://seunglab.org/" target="_blank">Seung Lab, Princeton University</a></li>
-    <li><a href="https://www.bbe.caltech.edu/people/thanos-siapas" target="_blank">Siapas Lab, California Institute of Technology</a></li>
-    <li><a href="https://www.cshl.edu/research/faculty-staff/tatiana-engel/" target="_blank">Engel Lab, Cold Spring Harbor Laboratory</a></li>
-    <li><a href="http://faculty.washington.edu/tuthill/" target="_blank">Tuthill Lab, University of Washington</a></li>
+    <li>California Institute of Technology
+        <ul>
+        <li><a href="https://www.bbe.caltech.edu/people/thanos-siapas" target="_blank">Siapas Lab</a></li>
+        </ul>
+    </li>
+    <li>Cold Spring Harbor Laboratory
+        <ul>
+        <li><a href="https://www.cshl.edu/research/faculty-staff/tatiana-engel/" target="_blank">Engel Lab</a></li>
+        </ul>
+    </li>
+    <li>EPFL
+        <ul>
+        <li><a href="http://www.mackenziemathislab.org/" target="_blank">Mackenzie Mathis Lab</a></li>
+        </ul>
+    </li>
+    <li>FORTH
+        <ul>
+        <li><a href="https://www.imbb.forth.gr/imbb-people/en/froudarakis-home" target="_blank">Emmanouil Froudarakis</a> (<a href="https://github.com/ef-lab" target="_blank">GitHub</a>)</li>
+        </ul>
+    </li>
+    <li>Harvard Medical School
+        <ul>        
+        <li><a href="http://datta.hms.harvard.edu/" target="_blank">Datta Lab</a></li>
+        <li><a href="https://harveylab.hms.harvard.edu/" target="_blank">Harvey Lab</a></li>
+        <li><a href="http://sabatini.hms.harvard.edu/" target="_blank">Sabatini Lab</a></li>
+        <li><a href="https://smirnakislab.bwh.harvard.edu/" target="_blank">Stelios Smirnakis Lab</a></li>
+        </ul>
+    </li>
     <li>Johns Hopkins University
         <ul>
         <li><a href="https://www.jhuapl.edu/" target="_blank">Applied Physics Lab</a> (<a href="https://github.com/aplbrain" target="_blank">GitHub</a>)</li>
+        </ul>
+    </li>
+    <li>Kavli Institute for Systems Neuroscience
+        <ul>
+        <li><a href="https://www.ntnu.edu/kavli/moser-group" target="_blank">Moser Group</a></li>
+        </ul>
+    </li>
+    <li>Ludwig-Maximilians-Universität München
+        <ul>
+        <li><a href="https://www.neuro.bio.lmu.de/research_groups/res-busse_l/index.html" target="_blank">Busse Lab</a></li>
+        <li><a href="https://www.neuro.bio.lmu.de/research_groups/res-katzner/index.html" target="_blank">Katzner Lab</a></li>
+        </ul>
+    </li>
+    <li>MIT
+        <ul>
+        <li><a href="https://www.wanglab-neuro.org" target="_blank">Fan Wang Lab</a></li>
+        </ul>
+    </li>
+    <li>Princeton University
+        <ul>
+        <li><a href="http://seunglab.org/" target="_blank">Seung Lab</a></li>
+        </ul>
+    </li>
+    <li>Stanford University
+        <ul>
+        <li><a href="http://web.stanford.edu/group/dlab/" target="_blank">Karl Deisseroth Lab</a></li>
         </ul>
     </li>
     <li>Northwestern University
@@ -97,18 +135,43 @@ Please visit our <a href="https://catalog.datajoint.io/" target="_blank">Catalog
         <li><a href="https://www.pintolab.org" target="_blank">Lucas Pinto</a></li>
         </ul>
     </li>
-    <li><a href="https://franklab.ucsf.edu/" target="_blank">Loren Frank Lab, University of California, San Francisco</a></li>
-    <li><a href="https://isearch.asu.edu/profile/500553" target="_blank">Rick Gerkin, Arizona State University</a></li>
-    <li><a href="https://www.imbb.forth.gr/imbb-people/en/froudarakis-home" target="_blank">Emmanouil Froudarakis, FORTH</a> (<a href="https://github.com/ef-lab" target="_blank">GitHub</a>)</li>
+    <li>University of Indiana
+        <ul>
+        <li><a href="http://www.lulaboratory.com/" target="_blank">Lu Lab</a></li>
+        </ul>
+    </li>
+    <li>University of California, Los Angeles
+        <ul>
+        <li><a href="https://churchlandlab.org/" target="_blank">Anne Churchland Lab</a></li>
+        </ul>
+    </li>
+    <li>University of California, San Diego
+        <ul>
+        <li><a href="https://neurophysics.ucsd.edu" target="_blank">David Kleinfeld Lab</a> (<a href="https://github.com/ActiveBrainAtlas" target="_blank">GitHub</a>)</li>
+        </ul>
+    </li>
+    <li>University of California, San Francisco
+        <ul>
+        <li><a href="https://franklab.ucsf.edu/" target="_blank">Loren Frank Lab</a></li>
+        </ul>
+    </li>
     <li>University of Oregon
         <ul>
         <li><a href="https://ion.uoregon.edu/content/santiago-jaramillo" target="_blank">Santiago Jaramillo Lab</a> (<a href="https://github.com/sjara/uobrainflex" target="_blank">GitHub</a>)</li>
         <li><a href="https://ion.uoregon.edu/content/michael-wehr" target="_blank">Michael Wehr Lab</a> (<a href="https://github.com/wehr-lab" target="_blank">GitHub</a>)</li>
         </ul>
     </li>
-    <li>University of California, San Diego
+    <li>University of Washington
         <ul>
-        <li><a href="https://neurophysics.ucsd.edu" target="_blank">David Kleinfeld</a> (<a href="https://github.com/ActiveBrainAtlas" target="_blank">GitHub</a>)</li>
+        <li><a href="http://faculty.washington.edu/tuthill/" target="_blank">Tuthill Lab</a></li>
+        </ul>
+    </li>
+    <li>Wilhelm Schickard Institute for Computer Science
+        <ul>
+        <li><a href="https://sinzlab.org/" target="_blank">Sinz Lab</a></li>
+        <li><a href="https://philippberens.wordpress.com/" target="_blank">Berens Lab</a></li>
+        <li><a href="http://www.eye-tuebingen.de/eulerlab/" target="_blank">Euler Lab</a></li>
+        <li><a href="http://bethgelab.org/" target="_blank">Bethge Lab</a></li>
         </ul>
     </li>
     <li>&#8230; and 40+ other labs</li>

--- a/gh-pages/docs/community/projects.md
+++ b/gh-pages/docs/community/projects.md
@@ -97,6 +97,11 @@ Please visit our <a href="https://catalog.datajoint.io/" target="_blank">Catalog
     <li><a href="https://franklab.ucsf.edu/" target="_blank">Loren Frank Lab, University of California, San Francisco</a></li>
     <li><a href="https://isearch.asu.edu/profile/500553" target="_blank">Rick Gerkin, Arizona State University</a></li>
     <li><a href="https://www.imbb.forth.gr/imbb-people/en/froudarakis-home" target="_blank">Emmanouil Froudarakis, FORTH</a> (<a href="https://github.com/ef-lab" target="_blank">GitHub</a>)</li>
+    <li>University of Oregon
+        <ul>
+        <li><a href="https://ion.uoregon.edu/content/michael-wehr" target="_blank">Michael Wehr Lab</a> (<a href="https://github.com/wehr-lab" target="_blank">GitHub</a>)</li>
+        </ul>
+    </li>
     <li>University of California, San Diego
         <ul>
         <li><a href="https://neurophysics.ucsd.edu" target="_blank">David Kleinfeld</a> (<a href="https://github.com/ActiveBrainAtlas" target="_blank">GitHub</a>)</li>

--- a/gh-pages/docs/community/projects.md
+++ b/gh-pages/docs/community/projects.md
@@ -11,6 +11,9 @@ Please visit our <a href="https://catalog.datajoint.io/" target="_blank">Catalog
 <ul>
     <li><a href="https://www.internationalbrainlab.com/#home" target="_blank">International Brain Lab</a> (<a href="https://github.com/int-brain-lab" target="_blank">GitHub</a>)</li>
     <li><a href="https://www.simonsfoundation.org/funded-project/multi-regional-neuronal-dynamics-of-memory-guided-flexible-behavior/" target="_blank">Mesoscale Activity Project</a></li>
+        <ul>
+        <li><a href="https://www.bcm.edu/research/faculty-labs/nuo-li-lab" target="_blank">Nuo Li Lab</a></li>
+        </ul>
     <li><a href="https://www.microns-explorer.org" target="_blank">MICrONS</a></li>
     <li>Sainsbury Wellcome Centre<a href="https://www.sainsburywellcome.org/web/" target="_blank"> Aeon</a></li>
     <li>U19 Awards
@@ -99,6 +102,7 @@ Please visit our <a href="https://catalog.datajoint.io/" target="_blank">Catalog
     <li><a href="https://www.imbb.forth.gr/imbb-people/en/froudarakis-home" target="_blank">Emmanouil Froudarakis, FORTH</a> (<a href="https://github.com/ef-lab" target="_blank">GitHub</a>)</li>
     <li>University of Oregon
         <ul>
+        <li><a href="https://ion.uoregon.edu/content/santiago-jaramillo" target="_blank">Santiago Jaramillo Lab</a> (<a href="https://github.com/sjara/uobrainflex" target="_blank">GitHub</a>)</li>
         <li><a href="https://ion.uoregon.edu/content/michael-wehr" target="_blank">Michael Wehr Lab</a> (<a href="https://github.com/wehr-lab" target="_blank">GitHub</a>)</li>
         </ul>
     </li>

--- a/gh-pages/docs/community/projects.md
+++ b/gh-pages/docs/community/projects.md
@@ -135,6 +135,11 @@ Please visit our <a href="https://catalog.datajoint.io/" target="_blank">Catalog
         <li><a href="https://www.pintolab.org" target="_blank">Lucas Pinto Lab</a></li>
         </ul>
     </li>
+    <li>Tel-Aviv University
+        <ul>
+        <li><a href="http://pblab.tau.ac.il/en/" target="_blank">Pablo Blinder Lab</a> (<a href="https://github.com/PBLab" target="_blank">GitHub</a>)</li>
+        </ul>
+    </li>
     <li>University of Indiana
         <ul>
         <li><a href="http://www.lulaboratory.com/" target="_blank">Lu Lab</a></li>

--- a/gh-pages/docs/community/projects.md
+++ b/gh-pages/docs/community/projects.md
@@ -179,5 +179,5 @@ Please visit our <a href="https://catalog.datajoint.io/" target="_blank">Catalog
         <li><a href="http://bethgelab.org/" target="_blank">Bethge Lab</a></li>
         </ul>
     </li>
-    <li>&#8230; and 40+ other labs</li>
+    <li>&#8230; and other labs</li>
 </ul>

--- a/gh-pages/docs/community/projects.md
+++ b/gh-pages/docs/community/projects.md
@@ -83,10 +83,19 @@ Please visit our <a href="https://catalog.datajoint.io/" target="_blank">Catalog
     <li><a href="https://www.bbe.caltech.edu/people/thanos-siapas" target="_blank">Siapas Lab, California Institute of Technology</a></li>
     <li><a href="https://www.cshl.edu/research/faculty-staff/tatiana-engel/" target="_blank">Engel Lab, Cold Spring Harbor Laboratory</a></li>
     <li><a href="http://faculty.washington.edu/tuthill/" target="_blank">Tuthill Lab, University of Washington</a></li>
-    <li><a href="https://www.jhuapl.edu/" target="_blank">Applied Physics Lab, Johns Hopkins University</a></li>
+    <li>Johns Hopkins University
+        <ul>
+        <li><a href="https://www.jhuapl.edu/" target="_blank">Applied Physics Lab</a> (<a href="https://github.com/aplbrain" target="_blank">GitHub</a>)</li>
+        </ul>
+    </li>
+    <li>Northwestern University
+        <ul>
+        <li><a href="https://www.feinberg.northwestern.edu/faculty-profiles/az/profile.html?xid=49313" target="_blank">James Cotton</a> (<a href="https://github.com/peabody124/PosePipeline" target="_blank">GitHub</a>)</li>
+        <li><a href="https://www.pintolab.org" target="_blank">Lucas Pinto</a></li>
+        </ul>
+    </li>
     <li><a href="https://franklab.ucsf.edu/" target="_blank">Loren Frank Lab, University of California, San Francisco</a></li>
     <li><a href="https://isearch.asu.edu/profile/500553" target="_blank">Rick Gerkin, Arizona State University</a></li>
-    <li><a href="https://www.pintolab.org" target="_blank">Lucas Pinto, Northwestern University</a></li>
     <li><a href="https://www.imbb.forth.gr/imbb-people/en/froudarakis-home" target="_blank">Emmanouil Froudarakis, FORTH</a> (<a href="https://github.com/ef-lab" target="_blank">GitHub</a>)</li>
     <li>University of California, San Diego
         <ul>

--- a/gh-pages/docs/community/projects.md
+++ b/gh-pages/docs/community/projects.md
@@ -28,9 +28,9 @@ Please visit our <a href="https://catalog.datajoint.io/" target="_blank">Catalog
             <li><a href="https://wittenlab.org" target="_blank">Ilana Witten Lab</a></li>
             <li><a href="https://pillowlab.princeton.edu" target="_blank">Jonathan Pillow Lab</a></li>
         </ul>
-        <li>Rochester-Harvard-NYU<a href="https://reporter.nih.gov/project-details/10047607" target="_blank"> Neural basis of causal inference</a></li>
+        <li>Rochester-NYU-Harvard<a href="https://reporter.nih.gov/project-details/10047607" target="_blank"> Neural basis of causal inference</a></li>
             <ul>
-            <li><a href="http://www.sas.rochester.edu/bcs/people/faculty/deangelis_greg/index.html" target="_blank">Greg DeAngelis, University of Rochester</a></li>
+            <li><a href="http://www.sas.rochester.edu/bcs/people/faculty/deangelis_greg/index.html" target="_blank">Greg DeAngelis Lab, University of Rochester</a></li>
             <li><a href="https://angelakilabnyu.org/" target="_blank">Dora Angelaki Lab, New York University</a></li>
             </ul>
         </ul>
@@ -48,7 +48,7 @@ Please visit our <a href="https://catalog.datajoint.io/" target="_blank">Catalog
     </li>
     <li>Arizona State University
         <ul>
-        <li><a href="https://isearch.asu.edu/profile/500553" target="_blank">Rick Gerkin</a></li>
+        <li><a href="https://isearch.asu.edu/profile/500553" target="_blank">Rick Gerkin Lab</a></li>
         </ul>
     </li>
     <li>Baylor College of Medicine
@@ -87,7 +87,7 @@ Please visit our <a href="https://catalog.datajoint.io/" target="_blank">Catalog
     </li>
     <li>FORTH
         <ul>
-        <li><a href="https://www.imbb.forth.gr/imbb-people/en/froudarakis-home" target="_blank">Emmanouil Froudarakis</a> (<a href="https://github.com/ef-lab" target="_blank">GitHub</a>)</li>
+        <li><a href="https://www.imbb.forth.gr/imbb-people/en/froudarakis-home" target="_blank">Emmanouil Froudarakis Lab</a> (<a href="https://github.com/ef-lab" target="_blank">GitHub</a>)</li>
         </ul>
     </li>
     <li>Harvard Medical School
@@ -131,8 +131,8 @@ Please visit our <a href="https://catalog.datajoint.io/" target="_blank">Catalog
     </li>
     <li>Northwestern University
         <ul>
-        <li><a href="https://www.feinberg.northwestern.edu/faculty-profiles/az/profile.html?xid=49313" target="_blank">James Cotton</a> (<a href="https://github.com/peabody124/PosePipeline" target="_blank">GitHub</a>)</li>
-        <li><a href="https://www.pintolab.org" target="_blank">Lucas Pinto</a></li>
+        <li><a href="https://www.feinberg.northwestern.edu/faculty-profiles/az/profile.html?xid=49313" target="_blank">James Cotton Lab</a> (<a href="https://github.com/peabody124/PosePipeline" target="_blank">GitHub</a>)</li>
+        <li><a href="https://www.pintolab.org" target="_blank">Lucas Pinto Lab</a></li>
         </ul>
     </li>
     <li>University of Indiana

--- a/gh-pages/docs/community/publications.md
+++ b/gh-pages/docs/community/publications.md
@@ -1,6 +1,12 @@
 <h1>Publications</h1>
 
-<p>The following publications relied on DataJoint open-source software for data analysis.  If your work uses DataJoint or DataJoint Elements, please cite the following:</p>
+<p>The following publications relied on DataJoint open-source software for data analysis.</p>
+
+<p>
+If you would like make additions or corrections, please submit an issue in the <a href="https://github.com/datajoint/datajoint-elements/issues" target="_blank" style="color:#1589F0;">datajoint-elements repository</a>.
+</p>
+
+<p>If your work uses DataJoint or DataJoint Elements, please cite the following:</p>
 
 <p><b>DataJoint</b></p>
 <p style="margin-left:5%;">
@@ -14,10 +20,6 @@ Yatsenko D, Walker EY, Tolias AS. <a href="https://doi.org/10.48550/arXiv.1807.1
 <p><b>DataJoint Elements</b></p>
 <p style="margin-left:5%;">
 Yatsenko D, Nguyen T, Shen S, Gunalan K, Turner CA, Guzman R, Sasaki M, Sitonic D, Reimer J, Walker EY, Tolias AS. <a href="https://doi.org/10.1101/2021.03.30.437358" target="_blank" style="color:#1589F0;">DataJoint Elements: Data Workflows for Neurophysiology</a>. bioRxiv. 2021 Jan 1.
-</p>
-
-<p>
-If you would like make additions or corrections, please submit an issue in the <a href="https://github.com/datajoint/datajoint-elements/issues" target="_blank" style="color:#1589F0;">datajoint-elements repository</a>.
 </p><br>
 
 <div id="refs" class="references csl-bib-body hanging-indent"

--- a/gh-pages/docs/management/outreach.md
+++ b/gh-pages/docs/management/outreach.md
@@ -42,6 +42,15 @@ We conduct activities to disseminate Resource components for adoption in diverse
 
 In order to measure the effectiveness of the Resource, we conduct several activities to estimate the adoption and use of the Resource components:
 
-- A citation mechanims for individual components of the Resource
+- A citation mechanism for individual components of the Resource.
+
+     | Resource | RRID |
+     |:---------|:-----|
+     | DataJoint | [RRID:SCR_014543](https://scicrunch.org/resolver/SCR_014543) |
+     | DataJoint Element Session | [RRID:SCR_021896](https://scicrunch.org/resolver/SCR_021896) |
+     | DataJoint Element Array Electrophysiology | [RRID:SCR_021894](https://scicrunch.org/resolver/SCR_021894) |
+     | DataJoint Element Calcium Imaging | [RRID:SCR_021895](https://scicrunch.org/resolver/SCR_021895) |
+
 - Collect summary statistics of the number of downloads and repository forking.
+
 - A register for self-reporting for component adoption and use (see [DataJoint Census](https://community.datajoint.io)).

--- a/gh-pages/docs/management/outreach.md
+++ b/gh-pages/docs/management/outreach.md
@@ -44,4 +44,4 @@ In order to measure the effectiveness of the Resource, we conduct several activi
 
 - A citation mechanims for individual components of the Resource
 - Collect summary statistics of the number of downloads and repository forking.
-- A register for self-reporting for component adoption and use.
+- A register for self-reporting for component adoption and use (see [DataJoint Census](https://community.datajoint.io)).

--- a/gh-pages/mkdocs.yml
+++ b/gh-pages/mkdocs.yml
@@ -6,14 +6,14 @@ theme:
   disable_nav_previous_next: true
   disable_nav_search: false
 nav:
+  - community/publications.md
+  - community/projects.md
   - 'Usage':
     - usage/design-principles.md
     - usage/adopt.md
     - Setup: usage/install.md
     - usage/glossary.md
   - 'Community':
-    - community/publications.md
-    - community/projects.md
     - community/contribute.md
     - community/nwb.md
     - community/support.md


### PR DESCRIPTION
- Move `Publications` and `Projects` pages to top level navigation.
- List all institutions on `Projects` page.
- Add labs to `Projects` page.
- Add RRIDs.