### PR TITLE
Add Google Analytics site tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Elements are described in the position paper
 
 - [DataJoint CodeBook](https://codebook.datajoint.io) - interactive online tutorials
 
+## Feedback
+
+DataJoint and DataJoint Elements are supported by a NIH grant for disseminating open-source software for neuroscience research.  Your feedback is essential for continued funding.  Your feedback also helps shape the technology development roadmap for the DataJoint ecosystem.  Please tell us about your projects by filling out the [DataJoint Census](https://community.datajoint.io).
+
 ## Citation
 
 If your work uses DataJoint or DataJoint Elements, please cite the following:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Elements are described in the position paper
 
 ## Feedback
 
-DataJoint and DataJoint Elements are supported by a NIH grant for disseminating open-source software for neuroscience research.  Your feedback is essential for continued funding.  Your feedback also helps shape the technology development roadmap for the DataJoint ecosystem.  Please tell us about your projects by filling out the [DataJoint Census](https://community.datajoint.io).
+DataJoint and DataJoint Elements are supported by NIH grant U24 NS116470 for disseminating open-source software for neuroscience research.  Your feedback is essential for continued funding.  Your feedback also helps shape the technology development roadmap for the DataJoint ecosystem.  Please tell us about your projects by filling out the [DataJoint Census](https://community.datajoint.io).
 
 ## Citation
 

--- a/gh-pages/docs/community/projects.md
+++ b/gh-pages/docs/community/projects.md
@@ -134,6 +134,11 @@ Please let us know if you would like to add another group or make other correcti
         <li><a href="http://seunglab.org/" target="_blank">Seung Lab</a></li>
         </ul>
     </li>
+    <li>Sainsbury Wellcome Centre
+        <ul>
+        <li><a href="https://branco-lab.org" target="_blank">Tiago Branco Lab</a> (<a href="https://github.com/BrancoLab/LocomotionControl" target="_blank">GitHub</a>)</li>
+        </ul>
+    </li>
     <li>Stanford University
         <ul>
         <li><a href="http://web.stanford.edu/group/dlab/" target="_blank">Karl Deisseroth Lab</a></li>

--- a/gh-pages/docs/management/quality-assurance.md
+++ b/gh-pages/docs/management/quality-assurance.md
@@ -4,7 +4,7 @@ DataJoint and DataJoint Elements serve as a framework and starting points for nu
 
 ## Coding Standards
 
-When writting code, the following principles should be observed.
+When writing code, the following principles should be observed.
 
 - **Style**: Code shall be written for clear readability. Uniform and clear naming conventions, module structure, and formatting requirements shall be established across all components of the project. Python's [PEP8](https://www.python.org/dev/peps/pep-0008/#naming-conventions) standard offers clear guidance to this regard which can similarly be applied to all languages.
 

--- a/gh-pages/mkdocs.yml
+++ b/gh-pages/mkdocs.yml
@@ -5,6 +5,8 @@ theme:
   custom_dir: themes/cinder-theme-ext
   disable_nav_previous_next: true
   disable_nav_search: false
+  analytics:
+    gtag: G-67GBDT81TP
 nav:
   - community/publications.md
   - community/projects.md


### PR DESCRIPTION
- Add Google Analytics site tag.  This configuration should work for [MkDocs](https://www.mkdocs.org/user-guide/choosing-your-theme/#readthedocs).
- Add census to readme
- Add lab 