### PR TITLE
Revert "Added Saunders et al publication to publications.md"

### DIFF
--- a/docs/publications.md
+++ b/docs/publications.md
@@ -22,13 +22,7 @@ line-spacing="2">
 
 <h3>2022</h3>
 
-<!-- 2022 ---> <div id="ref-saunders2022autopilot" class="csl-entry"> 
-
-Saunders, J. L., Ott, L. A., Wehr, M. (2022). <a href="https://doi.org/10.1101/807693" target="_blank", style="color:#1589F0;">AUTOPILOT: Automating experiments with lots of Raspberry Pis</a>. <i>bioRxiv.</i>
-
-</div><br />
-
-<!-- 2022 ---> <div id="ref-born2022effect" class="csl-entry"> 
+<!-- 2022 ---> <div id="ref-cadena2022diverse" class="csl-entry"> 
 
 Born, G. (2022). <a href="https://edoc.ub.uni-muenchen.de/30350/1/Born_Gregory.pdf" target="_blank" style="color:#1589F0;">The effect of feedback on sensory processing in the mouse early visual system</a>. <i>Doctoral dissertation</i>.
 


### PR DESCRIPTION
Reverts datajoint/datajoint-elements#143

Hi @kushalbakshi - It looked like this was self-merged, is that right? As a general rule, everything no matter how small should undergo some kind of review. The only repo that is an exception to this is [the science-team](https://github.com/datajoint-company/science-team) tutorials repo

Please revert and request my review for next time. I think we could also add [this issue](https://github.com/datajoint/datajoint-elements/issues/142) in the next PR